### PR TITLE
Replace full-width closing parenthesis with half-width in utils.py

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -19,7 +19,7 @@ def get_api_response(content: str, max_tokens=None):
         #model='gpt-4',
         #model='gpt-4-0613',
         #model='gpt-4-32k-0613',
-        temperature=0.5）
+        temperature=0.5)
 
 
     # response = openai.ChatCompletion.create(


### PR DESCRIPTION
This commit addresses an issue caused by using full-width closing parentheses in the utils.py file. These characters, represented as '）', can lead to code errors because most programming languages, including Python, don't interpret them the same as regular, half-width characters.

To avoid any possible issues related to character encoding or syntax errors arising from the use of full-width characters, we've replaced all instances of the full-width closing parenthesis '）' with the standard half-width closing parenthesis ')'. This change should help ensure that the code in utils.py runs smoothly and as expected.